### PR TITLE
Don't format code in pre-tags

### DIFF
--- a/code-style/neo4j-intellij.xml
+++ b/code-style/neo4j-intellij.xml
@@ -21,6 +21,9 @@
   <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
   <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
   <option name="WRAP_COMMENTS" value="true" />
+  <option name="FORMATTER_TAGS_ENABLED" value="true" />
+  <option name="FORMATTER_OFF_TAG" value="&lt;pre&gt;" />
+  <option name="FORMATTER_ON_TAG" value="&lt;/pre&gt;" />
   <JavaCodeStyleSettings>
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
   </JavaCodeStyleSettings>


### PR DESCRIPTION
Tell the Intellij formatter that code within `<pre> ... </pre>` tags is already formatted, and should not be touched.
This is highly useful when writing code samples in javadoc, but also when the formatter just does things wrong.