### PR TITLE
Never import with wildcard in Java files

### DIFF
--- a/code-style/neo4j-intellij.xml
+++ b/code-style/neo4j-intellij.xml
@@ -1,7 +1,7 @@
 <code_scheme name="neo4j-new">
   <option name="LINE_SEPARATOR" value="&#xA;" />
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5000" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5000" />
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
       <package name="" withSubpackages="true" static="false" />


### PR DESCRIPTION
Intellij should never replace many imports with a wildcard. 

Unfortunately Intellij don't have an option to completely turn this behavior off, so we need an arbitrarily big constant.